### PR TITLE
fix chromium poster download to include the profile picture

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,14 @@
         return;
       }
 
-      output.src = URL.createObjectURL(event.target.files[0]);
+      // Fix: image was loaded as blob, now we load it as data URL
+      // which html2canvas can render without triggering blob-related CORS errors.
+      const reader = new FileReader();
+      reader.onload = function(e) {
+          output.src = e.target.result;
+      };
+      reader.readAsDataURL(event.target.files[0]);
+
       output.onload = () => URL.revokeObjectURL(output.src);
     }
 


### PR DESCRIPTION
- It was an simple blob issue, which is solved while taking image data as URL

Here is a video to confirm:



https://github.com/user-attachments/assets/d824ea07-7050-4005-860f-00b7e77ea4e2



